### PR TITLE
feat(api): read path — GetDailyNote, GetTagLens, GetTags (#7)

### DIFF
--- a/apps/api/src/modules/projection/dto/tag-lens-query.dto.ts
+++ b/apps/api/src/modules/projection/dto/tag-lens-query.dto.ts
@@ -1,0 +1,23 @@
+import { IsOptional, IsDateString, IsInt, Min, Max, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class TagLensQueryDto {
+  @IsDateString()
+  @IsOptional()
+  from?: string;
+
+  @IsDateString()
+  @IsOptional()
+  to?: string;
+
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number;
+
+  @IsString()
+  @IsOptional()
+  cursor?: string;
+}

--- a/apps/api/src/modules/projection/projection.controller.ts
+++ b/apps/api/src/modules/projection/projection.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Param, Query, UseGuards, Request } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { GetDailyNoteQuery } from './queries/get-daily-note.query';
+import { GetTagLensQuery } from './queries/get-tag-lens.query';
+import { GetTagsQuery } from './queries/get-tags.query';
+import { TagLensQueryDto } from './dto/tag-lens-query.dto';
+import type { DailyNoteResult, TagLensResult, TagRecord } from '@notebase/shared';
+
+interface AuthRequest {
+  user: { sub: string };
+}
+
+@Controller()
+@UseGuards(JwtAuthGuard)
+export class ProjectionController {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  @Get('v1/daily-notes/:date')
+  getDailyNote(
+    @Param('date') date: string,
+    @Request() req: AuthRequest,
+  ): Promise<DailyNoteResult> {
+    return this.queryBus.execute(new GetDailyNoteQuery(req.user.sub, date));
+  }
+
+  @Get('v1/tags')
+  getTags(@Request() req: AuthRequest): Promise<TagRecord[]> {
+    return this.queryBus.execute(new GetTagsQuery(req.user.sub));
+  }
+
+  @Get('v1/tags/:tagId/lens')
+  getTagLens(
+    @Param('tagId') tagId: string,
+    @Query() queryDto: TagLensQueryDto,
+    @Request() req: AuthRequest,
+  ): Promise<TagLensResult> {
+    return this.queryBus.execute(
+      new GetTagLensQuery(req.user.sub, tagId, {
+        from: queryDto.from,
+        to: queryDto.to,
+        limit: queryDto.limit,
+        cursor: queryDto.cursor,
+      }),
+    );
+  }
+}

--- a/apps/api/src/modules/projection/projection.module.ts
+++ b/apps/api/src/modules/projection/projection.module.ts
@@ -1,11 +1,15 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
+import { ProjectionController } from './projection.controller';
+import { GetDailyNoteHandler } from './queries/get-daily-note.handler';
+import { GetTagLensHandler } from './queries/get-tag-lens.handler';
+import { GetTagsHandler } from './queries/get-tags.handler';
 
-/**
- * Handles read queries (GetDailyNote, GetTagLens, GetTags).
- * Query handlers are added in issue #7.
- */
+const QueryHandlers = [GetDailyNoteHandler, GetTagLensHandler, GetTagsHandler];
+
 @Module({
   imports: [CqrsModule],
+  controllers: [ProjectionController],
+  providers: [...QueryHandlers],
 })
 export class ProjectionModule {}

--- a/apps/api/src/modules/projection/queries/get-daily-note.handler.spec.ts
+++ b/apps/api/src/modules/projection/queries/get-daily-note.handler.spec.ts
@@ -1,0 +1,56 @@
+import { Test } from '@nestjs/testing';
+import { GetDailyNoteHandler } from './get-daily-note.handler';
+import { GetDailyNoteQuery } from './get-daily-note.query';
+import { PROJECTION_STORE } from '../../../infrastructure/infrastructure.module';
+import type { IProjectionStore, DailyNoteResult } from '@notebase/shared';
+
+describe('GetDailyNoteHandler', () => {
+  let handler: GetDailyNoteHandler;
+  let projectionStore: jest.Mocked<IProjectionStore>;
+
+  const mockResult: DailyNoteResult = {
+    date: '2026-03-29',
+    nodes: [
+      {
+        nodeId: 'node-1',
+        content: 'Test content',
+        parentId: null,
+        position: 0,
+        depth: 0,
+        tags: ['work'],
+        updatedAt: '2026-03-29T10:00:00.000Z',
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    projectionStore = {
+      getDailyNote: jest.fn().mockResolvedValue(mockResult),
+      upsertDailyNoteNode: jest.fn(),
+      deleteDailyNoteNode: jest.fn(),
+      upsertTagLensNode: jest.fn(),
+      deleteTagLensNode: jest.fn(),
+      getTagLens: jest.fn(),
+      upsertTag: jest.fn(),
+      getTags: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        GetDailyNoteHandler,
+        { provide: PROJECTION_STORE, useValue: projectionStore },
+      ],
+    }).compile();
+
+    handler = module.get(GetDailyNoteHandler);
+  });
+
+  it('delegates to projectionStore.getDailyNote and returns the result', async () => {
+    const query = new GetDailyNoteQuery('user-1', '2026-03-29');
+    const result = await handler.execute(query);
+
+    expect(projectionStore.getDailyNote).toHaveBeenCalledTimes(1);
+    expect(projectionStore.getDailyNote).toHaveBeenCalledWith('user-1', '2026-03-29');
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/apps/api/src/modules/projection/queries/get-daily-note.handler.ts
+++ b/apps/api/src/modules/projection/queries/get-daily-note.handler.ts
@@ -1,0 +1,16 @@
+import { QueryHandler, IQueryHandler } from '@nestjs/cqrs';
+import { Inject } from '@nestjs/common';
+import { GetDailyNoteQuery } from './get-daily-note.query';
+import { PROJECTION_STORE } from '../../../infrastructure/infrastructure.module';
+import type { IProjectionStore, DailyNoteResult } from '@notebase/shared';
+
+@QueryHandler(GetDailyNoteQuery)
+export class GetDailyNoteHandler implements IQueryHandler<GetDailyNoteQuery> {
+  constructor(
+    @Inject(PROJECTION_STORE) private readonly projectionStore: IProjectionStore,
+  ) {}
+
+  execute(query: GetDailyNoteQuery): Promise<DailyNoteResult> {
+    return this.projectionStore.getDailyNote(query.userId, query.date);
+  }
+}

--- a/apps/api/src/modules/projection/queries/get-daily-note.query.ts
+++ b/apps/api/src/modules/projection/queries/get-daily-note.query.ts
@@ -1,0 +1,6 @@
+export class GetDailyNoteQuery {
+  constructor(
+    public readonly userId: string,
+    public readonly date: string,
+  ) {}
+}

--- a/apps/api/src/modules/projection/queries/get-tag-lens.handler.spec.ts
+++ b/apps/api/src/modules/projection/queries/get-tag-lens.handler.spec.ts
@@ -1,0 +1,68 @@
+import { Test } from '@nestjs/testing';
+import { GetTagLensHandler } from './get-tag-lens.handler';
+import { GetTagLensQuery } from './get-tag-lens.query';
+import { PROJECTION_STORE } from '../../../infrastructure/infrastructure.module';
+import type { IProjectionStore, TagLensResult } from '@notebase/shared';
+
+describe('GetTagLensHandler', () => {
+  let handler: GetTagLensHandler;
+  let projectionStore: jest.Mocked<IProjectionStore>;
+
+  const mockResult: TagLensResult = {
+    tagId: 'tag-1',
+    tagName: 'work',
+    nodes: [
+      {
+        nodeId: 'node-1',
+        content: 'Test content',
+        dailyNoteDate: '2026-03-29',
+        parentId: null,
+        position: 0,
+        childCount: 0,
+        updatedAt: '2026-03-29T10:00:00.000Z',
+      },
+    ],
+    nextCursor: null,
+  };
+
+  beforeEach(async () => {
+    projectionStore = {
+      getTagLens: jest.fn().mockResolvedValue(mockResult),
+      getDailyNote: jest.fn(),
+      upsertDailyNoteNode: jest.fn(),
+      deleteDailyNoteNode: jest.fn(),
+      upsertTagLensNode: jest.fn(),
+      deleteTagLensNode: jest.fn(),
+      upsertTag: jest.fn(),
+      getTags: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        GetTagLensHandler,
+        { provide: PROJECTION_STORE, useValue: projectionStore },
+      ],
+    }).compile();
+
+    handler = module.get(GetTagLensHandler);
+  });
+
+  it('delegates to projectionStore.getTagLens and returns the result', async () => {
+    const query = new GetTagLensQuery('user-1', 'tag-1', { from: '2026-01-01', limit: 50 });
+    const result = await handler.execute(query);
+
+    expect(projectionStore.getTagLens).toHaveBeenCalledTimes(1);
+    expect(projectionStore.getTagLens).toHaveBeenCalledWith('user-1', 'tag-1', {
+      from: '2026-01-01',
+      limit: 50,
+    });
+    expect(result).toEqual(mockResult);
+  });
+
+  it('passes empty options when none are provided', async () => {
+    const query = new GetTagLensQuery('user-1', 'tag-1');
+    await handler.execute(query);
+
+    expect(projectionStore.getTagLens).toHaveBeenCalledWith('user-1', 'tag-1', {});
+  });
+});

--- a/apps/api/src/modules/projection/queries/get-tag-lens.handler.ts
+++ b/apps/api/src/modules/projection/queries/get-tag-lens.handler.ts
@@ -1,0 +1,16 @@
+import { QueryHandler, IQueryHandler } from '@nestjs/cqrs';
+import { Inject } from '@nestjs/common';
+import { GetTagLensQuery } from './get-tag-lens.query';
+import { PROJECTION_STORE } from '../../../infrastructure/infrastructure.module';
+import type { IProjectionStore, TagLensResult } from '@notebase/shared';
+
+@QueryHandler(GetTagLensQuery)
+export class GetTagLensHandler implements IQueryHandler<GetTagLensQuery> {
+  constructor(
+    @Inject(PROJECTION_STORE) private readonly projectionStore: IProjectionStore,
+  ) {}
+
+  execute(query: GetTagLensQuery): Promise<TagLensResult> {
+    return this.projectionStore.getTagLens(query.userId, query.tagId, query.options);
+  }
+}

--- a/apps/api/src/modules/projection/queries/get-tag-lens.query.ts
+++ b/apps/api/src/modules/projection/queries/get-tag-lens.query.ts
@@ -1,0 +1,9 @@
+import type { TagLensQueryOptions } from '@notebase/shared';
+
+export class GetTagLensQuery {
+  constructor(
+    public readonly userId: string,
+    public readonly tagId: string,
+    public readonly options: TagLensQueryOptions = {},
+  ) {}
+}

--- a/apps/api/src/modules/projection/queries/get-tags.handler.spec.ts
+++ b/apps/api/src/modules/projection/queries/get-tags.handler.spec.ts
@@ -1,0 +1,46 @@
+import { Test } from '@nestjs/testing';
+import { GetTagsHandler } from './get-tags.handler';
+import { GetTagsQuery } from './get-tags.query';
+import { PROJECTION_STORE } from '../../../infrastructure/infrastructure.module';
+import type { IProjectionStore, TagRecord } from '@notebase/shared';
+
+describe('GetTagsHandler', () => {
+  let handler: GetTagsHandler;
+  let projectionStore: jest.Mocked<IProjectionStore>;
+
+  const mockTags: TagRecord[] = [
+    { tagId: 'tag-1', tagName: 'work', color: '#ff0000', createdAt: '2026-03-29T10:00:00.000Z' },
+    { tagId: 'tag-2', tagName: 'personal', color: null, createdAt: '2026-03-29T11:00:00.000Z' },
+  ];
+
+  beforeEach(async () => {
+    projectionStore = {
+      getTags: jest.fn().mockResolvedValue(mockTags),
+      getDailyNote: jest.fn(),
+      upsertDailyNoteNode: jest.fn(),
+      deleteDailyNoteNode: jest.fn(),
+      getTagLens: jest.fn(),
+      upsertTagLensNode: jest.fn(),
+      deleteTagLensNode: jest.fn(),
+      upsertTag: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        GetTagsHandler,
+        { provide: PROJECTION_STORE, useValue: projectionStore },
+      ],
+    }).compile();
+
+    handler = module.get(GetTagsHandler);
+  });
+
+  it('delegates to projectionStore.getTags and returns the result', async () => {
+    const query = new GetTagsQuery('user-1');
+    const result = await handler.execute(query);
+
+    expect(projectionStore.getTags).toHaveBeenCalledTimes(1);
+    expect(projectionStore.getTags).toHaveBeenCalledWith('user-1');
+    expect(result).toEqual(mockTags);
+  });
+});

--- a/apps/api/src/modules/projection/queries/get-tags.handler.ts
+++ b/apps/api/src/modules/projection/queries/get-tags.handler.ts
@@ -1,0 +1,16 @@
+import { QueryHandler, IQueryHandler } from '@nestjs/cqrs';
+import { Inject } from '@nestjs/common';
+import { GetTagsQuery } from './get-tags.query';
+import { PROJECTION_STORE } from '../../../infrastructure/infrastructure.module';
+import type { IProjectionStore, TagRecord } from '@notebase/shared';
+
+@QueryHandler(GetTagsQuery)
+export class GetTagsHandler implements IQueryHandler<GetTagsQuery> {
+  constructor(
+    @Inject(PROJECTION_STORE) private readonly projectionStore: IProjectionStore,
+  ) {}
+
+  execute(query: GetTagsQuery): Promise<TagRecord[]> {
+    return this.projectionStore.getTags(query.userId);
+  }
+}

--- a/apps/api/src/modules/projection/queries/get-tags.query.ts
+++ b/apps/api/src/modules/projection/queries/get-tags.query.ts
@@ -1,0 +1,3 @@
+export class GetTagsQuery {
+  constructor(public readonly userId: string) {}
+}

--- a/apps/api/test/projection.e2e-spec.ts
+++ b/apps/api/test/projection.e2e-spec.ts
@@ -1,0 +1,92 @@
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Pool } from 'pg';
+import { createTestApp, closeTestApp } from './app.e2e-setup';
+
+const E2E_USER_ID = '00000000-0000-0000-0000-000000000099';
+const TEST_TAG_ID = '550e8400-e29b-41d4-a716-446655440044';
+
+describe('Projection read path (e2e)', () => {
+  let app: NestFastifyApplication;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    process.env.LOCAL_AUTH_USER_ID = E2E_USER_ID;
+    app = await createTestApp();
+    pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+    await pool.query(`DELETE FROM events WHERE payload->>'userId' = $1`, [E2E_USER_ID]);
+    await pool.query(`DELETE FROM tags WHERE user_id = $1`, [E2E_USER_ID]);
+
+    // Seed a tag via the write path so GET /v1/tags has something to return
+    await app.inject({
+      method: 'POST',
+      url: '/v1/tags',
+      payload: { tagId: TEST_TAG_ID, tagName: 'readpathtest', color: '#aabbcc' },
+    });
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM events WHERE payload->>'userId' = $1`, [E2E_USER_ID]);
+    await pool.query(`DELETE FROM tags WHERE user_id = $1`, [E2E_USER_ID]);
+    await pool.end();
+    await closeTestApp();
+  });
+
+  it('GET /v1/daily-notes/:date returns 200 with date and nodes array', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/v1/daily-notes/2026-03-29',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{ date: string; nodes: unknown[] }>();
+    expect(body.date).toBe('2026-03-29');
+    expect(Array.isArray(body.nodes)).toBe(true);
+  });
+
+  it('GET /v1/tags returns 200 with array containing the seeded tag', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/v1/tags',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<Array<{ tagId: string; tagName: string; color: string | null }>>();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(1);
+    expect(body[0].tagId).toBe(TEST_TAG_ID);
+    expect(body[0].tagName).toBe('readpathtest');
+    expect(body[0].color).toBe('#aabbcc');
+  });
+
+  it('GET /v1/tags/:tagId/lens returns 200 with tagId and nodes array', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/v1/tags/${TEST_TAG_ID}/lens`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{ tagId: string; tagName: string; nodes: unknown[]; nextCursor: string | null }>();
+    expect(body.tagId).toBe(TEST_TAG_ID);
+    expect(Array.isArray(body.nodes)).toBe(true);
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it('GET /v1/tags/:tagId/lens accepts query params without error', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/v1/tags/${TEST_TAG_ID}/lens?from=2026-01-01&to=2026-03-29&limit=10`,
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('GET /v1/tags/:tagId/lens with invalid limit returns 400', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/v1/tags/${TEST_TAG_ID}/lens?limit=notanumber`,
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements issue #7: three query handlers + `ProjectionController`
- `GET /v1/daily-notes/:date` → `GetDailyNoteQuery` → `{ date, nodes[] }`
- `GET /v1/tags` → `GetTagsQuery` → `TagRecord[]`
- `GET /v1/tags/:tagId/lens` → `GetTagLensQuery` → `{ tagId, tagName, nodes[], nextCursor }` with optional query params `from`, `to`, `limit` (1–500), `cursor`
- All handlers are thin delegators to `IProjectionStore` — no business logic
- Unit tests for all 3 handlers (3 tests)
- E2E tests: seeds a tag via write path, then reads it back via `GET /v1/tags`; also covers query param validation (invalid limit → 400)

## Test plan

- [x] `pnpm --filter @notebase/api test` — 20 unit tests pass
- [x] Ensure `docker compose up` is running
- [x] `pnpm --filter @notebase/api test:e2e` — 23 tests pass across all 4 suites
- [x] `curl http://localhost:3000/v1/daily-notes/2026-03-29` → 200 `{ date, nodes: [] }`
- [x] `curl http://localhost:3000/v1/tags` → 200 `[]`
- [x] `curl "http://localhost:3000/v1/tags/<tagId>/lens?limit=10"` → 200
- [x] `curl "http://localhost:3000/v1/tags/<tagId>/lens?limit=notanumber"` → 400

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)