### PR TITLE
feat(api): Phase 1 projection handler — polling loop (#8)

### DIFF
--- a/apps/api/src/common/config/app.config.ts
+++ b/apps/api/src/common/config/app.config.ts
@@ -22,6 +22,10 @@ export default registerAs('app', () => ({
 
   projectionStore: process.env.PROJECTION_STORE ?? 'postgres',
 
+  projection: {
+    pollIntervalMs: parseInt(process.env.PROJECTION_POLL_INTERVAL_MS ?? '500', 10),
+  },
+
   dynamodb: {
     endpoint: process.env.DYNAMODB_ENDPOINT,
     region: process.env.DYNAMODB_REGION ?? 'ap-southeast-2',

--- a/apps/api/src/infrastructure/projection-store/postgres-projection-store.ts
+++ b/apps/api/src/infrastructure/projection-store/postgres-projection-store.ts
@@ -49,7 +49,7 @@ export class PostgresProjectionStore implements IProjectionStore, OnApplicationS
         node.parentId,
         node.position,
         node.depth,
-        JSON.stringify(node.tags),
+        node.tags,
         node.updatedAt,
       ],
     );
@@ -69,7 +69,7 @@ export class PostgresProjectionStore implements IProjectionStore, OnApplicationS
       parent_id: string | null;
       position: number;
       depth: number;
-      tags: string;
+      tags: string[];
       updated_at: string;
     }>(
       `SELECT node_id, content, parent_id, position, depth, tags, updated_at
@@ -87,7 +87,7 @@ export class PostgresProjectionStore implements IProjectionStore, OnApplicationS
         parentId: row.parent_id,
         position: row.position,
         depth: row.depth,
-        tags: JSON.parse(row.tags) as string[],
+        tags: row.tags,
         updatedAt: row.updated_at,
       })),
     };

--- a/apps/api/src/modules/projection/projection-handler.service.spec.ts
+++ b/apps/api/src/modules/projection/projection-handler.service.spec.ts
@@ -1,0 +1,368 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { ProjectionHandlerService } from './projection-handler.service';
+import { EVENT_STORE, PROJECTION_STORE } from '../../infrastructure/infrastructure.module';
+import type { IEventStore, IProjectionStore, StoredEvent } from '@notebase/shared';
+
+const USER = 'user-1';
+const DATE = '2026-03-29';
+const NODE_ID = 'node-1';
+const TAG_ID = 'tag-1';
+
+function makeStoredEvent(id: number, event: StoredEvent['event']): StoredEvent {
+  return { id, event };
+}
+
+describe('ProjectionHandlerService', () => {
+  let service: ProjectionHandlerService;
+  let eventStore: jest.Mocked<IEventStore>;
+  let projectionStore: jest.Mocked<IProjectionStore>;
+
+  beforeEach(async () => {
+    eventStore = {
+      append: jest.fn(),
+      getEventsSince: jest.fn().mockResolvedValue([]),
+    };
+    projectionStore = {
+      upsertDailyNoteNode: jest.fn().mockResolvedValue(undefined),
+      deleteDailyNoteNode: jest.fn().mockResolvedValue(undefined),
+      getDailyNote: jest.fn(),
+      upsertTagLensNode: jest.fn().mockResolvedValue(undefined),
+      deleteTagLensNode: jest.fn().mockResolvedValue(undefined),
+      getTagLens: jest.fn(),
+      upsertTag: jest.fn().mockResolvedValue(undefined),
+      getTags: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        ProjectionHandlerService,
+        { provide: EVENT_STORE, useValue: eventStore },
+        { provide: PROJECTION_STORE, useValue: projectionStore },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(500) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(ProjectionHandlerService);
+  });
+
+  describe('NodeCreated', () => {
+    it('upserts into projection_daily_note with depth 0 for root nodes', async () => {
+      eventStore.getEventsSince.mockResolvedValueOnce([
+        makeStoredEvent(1, {
+          type: 'NodeCreated',
+          eventId: 'e1',
+          userId: USER,
+          nodeId: NODE_ID,
+          content: 'Hello',
+          parentId: null,
+          dailyNoteDate: DATE,
+          position: 0,
+          occurredAt: '2026-03-29T10:00:00.000Z',
+        }),
+      ]);
+
+      await service.pollOnce();
+
+      expect(projectionStore.upsertDailyNoteNode).toHaveBeenCalledTimes(1);
+      const [userId, date, node] = projectionStore.upsertDailyNoteNode.mock.calls[0];
+      expect(userId).toBe(USER);
+      expect(date).toBe(DATE);
+      expect(node.nodeId).toBe(NODE_ID);
+      expect(node.content).toBe('Hello');
+      expect(node.depth).toBe(0);
+      expect(node.tags).toEqual([]);
+    });
+
+    it('sets depth 1 for a child node whose parent has been projected', async () => {
+      eventStore.getEventsSince.mockResolvedValueOnce([
+        makeStoredEvent(1, {
+          type: 'NodeCreated',
+          eventId: 'e1',
+          userId: USER,
+          nodeId: 'parent-node',
+          content: 'Parent',
+          parentId: null,
+          dailyNoteDate: DATE,
+          position: 0,
+          occurredAt: '2026-03-29T10:00:00.000Z',
+        }),
+        makeStoredEvent(2, {
+          type: 'NodeCreated',
+          eventId: 'e2',
+          userId: USER,
+          nodeId: 'child-node',
+          content: 'Child',
+          parentId: 'parent-node',
+          dailyNoteDate: DATE,
+          position: 0,
+          occurredAt: '2026-03-29T10:00:01.000Z',
+        }),
+      ]);
+
+      await service.pollOnce();
+
+      const childCall = projectionStore.upsertDailyNoteNode.mock.calls.find(
+        ([, , node]) => node.nodeId === 'child-node',
+      );
+      expect(childCall?.[2].depth).toBe(1);
+    });
+  });
+
+  describe('NodeEdited', () => {
+    it('updates content in daily note and tag lens projections', async () => {
+      eventStore.getEventsSince.mockResolvedValueOnce([
+        makeStoredEvent(1, {
+          type: 'NodeCreated',
+          eventId: 'e1',
+          userId: USER,
+          nodeId: NODE_ID,
+          content: 'Original',
+          parentId: null,
+          dailyNoteDate: DATE,
+          position: 0,
+          occurredAt: '2026-03-29T10:00:00.000Z',
+        }),
+        makeStoredEvent(2, {
+          type: 'TagCreated',
+          eventId: 'e2',
+          userId: USER,
+          tagId: TAG_ID,
+          tagName: 'work',
+          color: null,
+          occurredAt: '2026-03-29T10:00:01.000Z',
+        }),
+        makeStoredEvent(3, {
+          type: 'NodeTagged',
+          eventId: 'e3',
+          userId: USER,
+          nodeId: NODE_ID,
+          tagId: TAG_ID,
+          tagName: 'work',
+          occurredAt: '2026-03-29T10:00:02.000Z',
+        }),
+        makeStoredEvent(4, {
+          type: 'NodeEdited',
+          eventId: 'e4',
+          userId: USER,
+          nodeId: NODE_ID,
+          content: 'Updated',
+          occurredAt: '2026-03-29T10:00:03.000Z',
+        }),
+      ]);
+
+      await service.pollOnce();
+
+      // Last upsertDailyNoteNode call should have updated content
+      const calls = projectionStore.upsertDailyNoteNode.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[2].content).toBe('Updated');
+
+      // Tag lens should also be updated
+      const lensCall = projectionStore.upsertTagLensNode.mock.calls.find(
+        ([, , , node]) => node.content === 'Updated',
+      );
+      expect(lensCall).toBeDefined();
+    });
+  });
+
+  describe('NodeDeleted', () => {
+    it('deletes from daily note and all tag lens projections', async () => {
+      eventStore.getEventsSince.mockResolvedValueOnce([
+        makeStoredEvent(1, {
+          type: 'NodeCreated',
+          eventId: 'e1',
+          userId: USER,
+          nodeId: NODE_ID,
+          content: 'Hello',
+          parentId: null,
+          dailyNoteDate: DATE,
+          position: 0,
+          occurredAt: '2026-03-29T10:00:00.000Z',
+        }),
+        makeStoredEvent(2, {
+          type: 'NodeTagged',
+          eventId: 'e2',
+          userId: USER,
+          nodeId: NODE_ID,
+          tagId: TAG_ID,
+          tagName: 'work',
+          occurredAt: '2026-03-29T10:00:01.000Z',
+        }),
+        makeStoredEvent(3, {
+          type: 'NodeDeleted',
+          eventId: 'e3',
+          userId: USER,
+          nodeId: NODE_ID,
+          softDelete: false,
+          occurredAt: '2026-03-29T10:00:02.000Z',
+        }),
+      ]);
+
+      await service.pollOnce();
+
+      expect(projectionStore.deleteDailyNoteNode).toHaveBeenCalledWith(USER, DATE, NODE_ID);
+      expect(projectionStore.deleteTagLensNode).toHaveBeenCalledWith(USER, TAG_ID, NODE_ID);
+    });
+  });
+
+  describe('NodeTagged / NodeUntagged', () => {
+    it('adds node to tag lens on NodeTagged', async () => {
+      eventStore.getEventsSince.mockResolvedValueOnce([
+        makeStoredEvent(1, {
+          type: 'NodeCreated',
+          eventId: 'e1',
+          userId: USER,
+          nodeId: NODE_ID,
+          content: 'Hello',
+          parentId: null,
+          dailyNoteDate: DATE,
+          position: 0,
+          occurredAt: '2026-03-29T10:00:00.000Z',
+        }),
+        makeStoredEvent(2, {
+          type: 'NodeTagged',
+          eventId: 'e2',
+          userId: USER,
+          nodeId: NODE_ID,
+          tagId: TAG_ID,
+          tagName: 'work',
+          occurredAt: '2026-03-29T10:00:01.000Z',
+        }),
+      ]);
+
+      await service.pollOnce();
+
+      expect(projectionStore.upsertTagLensNode).toHaveBeenCalledTimes(1);
+      const [userId, tagId, tagName, node] =
+        projectionStore.upsertTagLensNode.mock.calls[0];
+      expect(userId).toBe(USER);
+      expect(tagId).toBe(TAG_ID);
+      expect(tagName).toBe('work');
+      expect(node.nodeId).toBe(NODE_ID);
+      expect(node.content).toBe('Hello');
+    });
+
+    it('removes node from tag lens on NodeUntagged', async () => {
+      eventStore.getEventsSince.mockResolvedValueOnce([
+        makeStoredEvent(1, {
+          type: 'NodeCreated',
+          eventId: 'e1',
+          userId: USER,
+          nodeId: NODE_ID,
+          content: 'Hello',
+          parentId: null,
+          dailyNoteDate: DATE,
+          position: 0,
+          occurredAt: '2026-03-29T10:00:00.000Z',
+        }),
+        makeStoredEvent(2, {
+          type: 'NodeTagged',
+          eventId: 'e2',
+          userId: USER,
+          nodeId: NODE_ID,
+          tagId: TAG_ID,
+          tagName: 'work',
+          occurredAt: '2026-03-29T10:00:01.000Z',
+        }),
+        makeStoredEvent(3, {
+          type: 'NodeUntagged',
+          eventId: 'e3',
+          userId: USER,
+          nodeId: NODE_ID,
+          tagId: TAG_ID,
+          occurredAt: '2026-03-29T10:00:02.000Z',
+        }),
+      ]);
+
+      await service.pollOnce();
+
+      expect(projectionStore.deleteTagLensNode).toHaveBeenCalledWith(USER, TAG_ID, NODE_ID);
+    });
+
+    it('updates tags array in daily note on NodeTagged', async () => {
+      eventStore.getEventsSince.mockResolvedValueOnce([
+        makeStoredEvent(1, {
+          type: 'NodeCreated',
+          eventId: 'e1',
+          userId: USER,
+          nodeId: NODE_ID,
+          content: 'Hello',
+          parentId: null,
+          dailyNoteDate: DATE,
+          position: 0,
+          occurredAt: '2026-03-29T10:00:00.000Z',
+        }),
+        makeStoredEvent(2, {
+          type: 'NodeTagged',
+          eventId: 'e2',
+          userId: USER,
+          nodeId: NODE_ID,
+          tagId: TAG_ID,
+          tagName: 'work',
+          occurredAt: '2026-03-29T10:00:01.000Z',
+        }),
+      ]);
+
+      await service.pollOnce();
+
+      const calls = projectionStore.upsertDailyNoteNode.mock.calls;
+      const taggedCall = calls[calls.length - 1];
+      expect(taggedCall[2].tags).toEqual(['work']);
+    });
+  });
+
+  describe('TagCreated', () => {
+    it('upserts tag into projection store', async () => {
+      eventStore.getEventsSince.mockResolvedValueOnce([
+        makeStoredEvent(1, {
+          type: 'TagCreated',
+          eventId: 'e1',
+          userId: USER,
+          tagId: TAG_ID,
+          tagName: 'work',
+          color: '#ff0000',
+          occurredAt: '2026-03-29T10:00:00.000Z',
+        }),
+      ]);
+
+      await service.pollOnce();
+
+      expect(projectionStore.upsertTag).toHaveBeenCalledWith(USER, {
+        tagId: TAG_ID,
+        tagName: 'work',
+        color: '#ff0000',
+        createdAt: '2026-03-29T10:00:00.000Z',
+      });
+    });
+  });
+
+  describe('cursor advancement', () => {
+    it('advances lastProcessedId so events are not reprocessed', async () => {
+      eventStore.getEventsSince
+        .mockResolvedValueOnce([
+          makeStoredEvent(5, {
+            type: 'NodeCreated',
+            eventId: 'e1',
+            userId: USER,
+            nodeId: NODE_ID,
+            content: 'Hello',
+            parentId: null,
+            dailyNoteDate: DATE,
+            position: 0,
+            occurredAt: '2026-03-29T10:00:00.000Z',
+          }),
+        ])
+        .mockResolvedValueOnce([]);
+
+      await service.pollOnce();
+      await service.pollOnce();
+
+      expect(eventStore.getEventsSince).toHaveBeenNthCalledWith(1, 0);
+      expect(eventStore.getEventsSince).toHaveBeenNthCalledWith(2, 5);
+    });
+  });
+});

--- a/apps/api/src/modules/projection/projection-handler.service.ts
+++ b/apps/api/src/modules/projection/projection-handler.service.ts
@@ -1,0 +1,291 @@
+import { Injectable, OnModuleInit, OnApplicationShutdown, Inject, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EVENT_STORE, PROJECTION_STORE } from '../../infrastructure/infrastructure.module';
+import type {
+  IEventStore,
+  IProjectionStore,
+  NoteBaseEvent,
+  NodeCreated,
+  NodeEdited,
+  NodeMoved,
+  NodeDeleted,
+  TagCreated,
+  NodeTagged,
+  NodeUntagged,
+} from '@notebase/shared';
+
+interface NodeState {
+  userId: string;
+  dailyNoteDate: string;
+  content: string;
+  parentId: string | null;
+  position: number;
+  depth: number;
+  tagIds: string[];
+  tagNames: string[];
+}
+
+@Injectable()
+export class ProjectionHandlerService implements OnModuleInit, OnApplicationShutdown {
+  private readonly logger = new Logger(ProjectionHandlerService.name);
+  private lastProcessedId = 0;
+  private readonly nodeStates = new Map<string, NodeState>();
+  private intervalHandle: NodeJS.Timeout | null = null;
+  private isPolling = false;
+
+  constructor(
+    @Inject(EVENT_STORE) private readonly eventStore: IEventStore,
+    @Inject(PROJECTION_STORE) private readonly projectionStore: IProjectionStore,
+    private readonly config: ConfigService,
+  ) {}
+
+  onModuleInit(): void {
+    const intervalMs = this.config.get<number>('app.projection.pollIntervalMs', 500);
+    this.intervalHandle = setInterval(() => {
+      void this.pollOnce();
+    }, intervalMs);
+  }
+
+  onApplicationShutdown(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+  }
+
+  async pollOnce(): Promise<void> {
+    if (this.isPolling) return;
+    this.isPolling = true;
+    try {
+      const stored = await this.eventStore.getEventsSince(this.lastProcessedId);
+      for (const { id, event } of stored) {
+        await this.processEvent(event);
+        this.lastProcessedId = id;
+      }
+    } catch (err) {
+      this.logger.error('Projection poll failed', err);
+    } finally {
+      this.isPolling = false;
+    }
+  }
+
+  private async processEvent(event: NoteBaseEvent): Promise<void> {
+    switch (event.type) {
+      case 'NodeCreated':
+        await this.onNodeCreated(event);
+        break;
+      case 'NodeEdited':
+        await this.onNodeEdited(event);
+        break;
+      case 'NodeMoved':
+        await this.onNodeMoved(event);
+        break;
+      case 'NodeDeleted':
+        await this.onNodeDeleted(event);
+        break;
+      case 'TagCreated':
+        await this.onTagCreated(event);
+        break;
+      case 'NodeTagged':
+        await this.onNodeTagged(event);
+        break;
+      case 'NodeUntagged':
+        await this.onNodeUntagged(event);
+        break;
+    }
+  }
+
+  private async onNodeCreated(event: NodeCreated): Promise<void> {
+    const parentState = event.parentId ? this.nodeStates.get(event.parentId) : null;
+    const depth = parentState ? parentState.depth + 1 : 0;
+
+    this.nodeStates.set(event.nodeId, {
+      userId: event.userId,
+      dailyNoteDate: event.dailyNoteDate,
+      content: event.content,
+      parentId: event.parentId,
+      position: event.position,
+      depth,
+      tagIds: [],
+      tagNames: [],
+    });
+
+    await this.projectionStore.upsertDailyNoteNode(event.userId, event.dailyNoteDate, {
+      nodeId: event.nodeId,
+      content: event.content,
+      parentId: event.parentId,
+      position: event.position,
+      depth,
+      tags: [],
+      updatedAt: event.occurredAt,
+    });
+  }
+
+  private async onNodeEdited(event: NodeEdited): Promise<void> {
+    const state = this.nodeStates.get(event.nodeId);
+    if (!state) {
+      this.logger.warn(`NodeEdited: no state found for node ${event.nodeId}`);
+      return;
+    }
+
+    state.content = event.content;
+
+    await this.projectionStore.upsertDailyNoteNode(event.userId, state.dailyNoteDate, {
+      nodeId: event.nodeId,
+      content: event.content,
+      parentId: state.parentId,
+      position: state.position,
+      depth: state.depth,
+      tags: state.tagNames,
+      updatedAt: event.occurredAt,
+    });
+
+    // Update content in all tag lens projections for this node
+    for (let i = 0; i < state.tagIds.length; i++) {
+      await this.projectionStore.upsertTagLensNode(
+        event.userId,
+        state.tagIds[i],
+        state.tagNames[i],
+        {
+          nodeId: event.nodeId,
+          content: event.content,
+          dailyNoteDate: state.dailyNoteDate,
+          parentId: state.parentId,
+          position: state.position,
+          childCount: 0,
+          updatedAt: event.occurredAt,
+        },
+      );
+    }
+  }
+
+  private async onNodeMoved(event: NodeMoved): Promise<void> {
+    const state = this.nodeStates.get(event.nodeId);
+    if (!state) {
+      this.logger.warn(`NodeMoved: no state found for node ${event.nodeId}`);
+      return;
+    }
+
+    const parentState = event.newParentId ? this.nodeStates.get(event.newParentId) : null;
+    const depth = parentState ? parentState.depth + 1 : 0;
+
+    state.parentId = event.newParentId;
+    state.position = event.newPosition;
+    state.depth = depth;
+
+    await this.projectionStore.upsertDailyNoteNode(event.userId, state.dailyNoteDate, {
+      nodeId: event.nodeId,
+      content: state.content,
+      parentId: event.newParentId,
+      position: event.newPosition,
+      depth,
+      tags: state.tagNames,
+      updatedAt: event.occurredAt,
+    });
+
+    for (let i = 0; i < state.tagIds.length; i++) {
+      await this.projectionStore.upsertTagLensNode(
+        event.userId,
+        state.tagIds[i],
+        state.tagNames[i],
+        {
+          nodeId: event.nodeId,
+          content: state.content,
+          dailyNoteDate: state.dailyNoteDate,
+          parentId: event.newParentId,
+          position: event.newPosition,
+          childCount: 0,
+          updatedAt: event.occurredAt,
+        },
+      );
+    }
+  }
+
+  private async onNodeDeleted(event: NodeDeleted): Promise<void> {
+    const state = this.nodeStates.get(event.nodeId);
+    if (!state) {
+      this.logger.warn(`NodeDeleted: no state found for node ${event.nodeId}`);
+      return;
+    }
+
+    await this.projectionStore.deleteDailyNoteNode(
+      event.userId,
+      state.dailyNoteDate,
+      event.nodeId,
+    );
+
+    for (const tagId of state.tagIds) {
+      await this.projectionStore.deleteTagLensNode(event.userId, tagId, event.nodeId);
+    }
+
+    this.nodeStates.delete(event.nodeId);
+  }
+
+  private async onTagCreated(event: TagCreated): Promise<void> {
+    await this.projectionStore.upsertTag(event.userId, {
+      tagId: event.tagId,
+      tagName: event.tagName,
+      color: event.color,
+      createdAt: event.occurredAt,
+    });
+  }
+
+  private async onNodeTagged(event: NodeTagged): Promise<void> {
+    const state = this.nodeStates.get(event.nodeId);
+    if (!state) {
+      this.logger.warn(`NodeTagged: no state found for node ${event.nodeId}`);
+      return;
+    }
+
+    if (!state.tagIds.includes(event.tagId)) {
+      state.tagIds.push(event.tagId);
+      state.tagNames.push(event.tagName);
+    }
+
+    await this.projectionStore.upsertDailyNoteNode(event.userId, state.dailyNoteDate, {
+      nodeId: event.nodeId,
+      content: state.content,
+      parentId: state.parentId,
+      position: state.position,
+      depth: state.depth,
+      tags: state.tagNames,
+      updatedAt: event.occurredAt,
+    });
+
+    await this.projectionStore.upsertTagLensNode(event.userId, event.tagId, event.tagName, {
+      nodeId: event.nodeId,
+      content: state.content,
+      dailyNoteDate: state.dailyNoteDate,
+      parentId: state.parentId,
+      position: state.position,
+      childCount: 0,
+      updatedAt: event.occurredAt,
+    });
+  }
+
+  private async onNodeUntagged(event: NodeUntagged): Promise<void> {
+    const state = this.nodeStates.get(event.nodeId);
+    if (!state) {
+      this.logger.warn(`NodeUntagged: no state found for node ${event.nodeId}`);
+      return;
+    }
+
+    const idx = state.tagIds.indexOf(event.tagId);
+    if (idx !== -1) {
+      state.tagIds.splice(idx, 1);
+      state.tagNames.splice(idx, 1);
+    }
+
+    await this.projectionStore.upsertDailyNoteNode(event.userId, state.dailyNoteDate, {
+      nodeId: event.nodeId,
+      content: state.content,
+      parentId: state.parentId,
+      position: state.position,
+      depth: state.depth,
+      tags: state.tagNames,
+      updatedAt: event.occurredAt,
+    });
+
+    await this.projectionStore.deleteTagLensNode(event.userId, event.tagId, event.nodeId);
+  }
+}

--- a/apps/api/src/modules/projection/projection.module.ts
+++ b/apps/api/src/modules/projection/projection.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { ProjectionController } from './projection.controller';
+import { ProjectionHandlerService } from './projection-handler.service';
 import { GetDailyNoteHandler } from './queries/get-daily-note.handler';
 import { GetTagLensHandler } from './queries/get-tag-lens.handler';
 import { GetTagsHandler } from './queries/get-tags.handler';
@@ -10,6 +11,6 @@ const QueryHandlers = [GetDailyNoteHandler, GetTagLensHandler, GetTagsHandler];
 @Module({
   imports: [CqrsModule],
   controllers: [ProjectionController],
-  providers: [...QueryHandlers],
+  providers: [...QueryHandlers, ProjectionHandlerService],
 })
 export class ProjectionModule {}

--- a/apps/api/test/projection-handler.e2e-spec.ts
+++ b/apps/api/test/projection-handler.e2e-spec.ts
@@ -1,0 +1,143 @@
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Pool } from 'pg';
+import { createTestApp, closeTestApp } from './app.e2e-setup';
+import { ProjectionHandlerService } from '../src/modules/projection/projection-handler.service';
+
+const E2E_USER_ID = '00000000-0000-0000-0000-000000000099';
+const TEST_NODE_ID = '550e8400-e29b-41d4-a716-446655440055';
+const TEST_TAG_ID = '550e8400-e29b-41d4-a716-446655440066';
+const DATE = '2026-03-29';
+
+describe('ProjectionHandler end-to-end (e2e)', () => {
+  let app: NestFastifyApplication;
+  let pool: Pool;
+  let handler: ProjectionHandlerService;
+
+  beforeAll(async () => {
+    process.env.LOCAL_AUTH_USER_ID = E2E_USER_ID;
+    app = await createTestApp();
+    pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    handler = app.get(ProjectionHandlerService);
+
+    // Clean slate
+    await pool.query(`DELETE FROM events WHERE payload->>'userId' = $1`, [E2E_USER_ID]);
+    await pool.query(`DELETE FROM tags WHERE user_id = $1`, [E2E_USER_ID]);
+    await pool.query(`DELETE FROM projection_daily_note WHERE user_id = $1`, [E2E_USER_ID]);
+    await pool.query(`DELETE FROM projection_tag_lens WHERE user_id = $1`, [E2E_USER_ID]);
+
+    // Reset handler cursor so it replays from the beginning of our test data
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (handler as any).lastProcessedId = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (handler as any).nodeStates.clear();
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM events WHERE payload->>'userId' = $1`, [E2E_USER_ID]);
+    await pool.query(`DELETE FROM tags WHERE user_id = $1`, [E2E_USER_ID]);
+    await pool.query(`DELETE FROM projection_daily_note WHERE user_id = $1`, [E2E_USER_ID]);
+    await pool.query(`DELETE FROM projection_tag_lens WHERE user_id = $1`, [E2E_USER_ID]);
+    await pool.end();
+    await closeTestApp();
+  });
+
+  it('projects NodeCreated into projection_daily_note', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/v1/nodes',
+      payload: {
+        nodeId: TEST_NODE_ID,
+        content: 'Projection handler test',
+        parentId: null,
+        dailyNoteDate: DATE,
+        position: 0,
+      },
+    });
+
+    await handler.pollOnce();
+
+    const response = await app.inject({ method: 'GET', url: `/v1/daily-notes/${DATE}` });
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{ date: string; nodes: Array<{ nodeId: string; content: string; tags: string[] }> }>();
+    const node = body.nodes.find((n) => n.nodeId === TEST_NODE_ID);
+    expect(node).toBeDefined();
+    expect(node?.content).toBe('Projection handler test');
+    expect(node?.tags).toEqual([]);
+  });
+
+  it('projects NodeEdited — updates content in daily note', async () => {
+    await app.inject({
+      method: 'PATCH',
+      url: `/v1/nodes/${TEST_NODE_ID}`,
+      payload: { content: 'Edited content' },
+    });
+
+    await handler.pollOnce();
+
+    const response = await app.inject({ method: 'GET', url: `/v1/daily-notes/${DATE}` });
+    const body = response.json<{ nodes: Array<{ nodeId: string; content: string }> }>();
+    const node = body.nodes.find((n) => n.nodeId === TEST_NODE_ID);
+    expect(node?.content).toBe('Edited content');
+  });
+
+  it('projects TagCreated + NodeTagged into tags table and tag lens', async () => {
+    // Create tag explicitly then tag the node
+    await app.inject({
+      method: 'POST',
+      url: '/v1/tags',
+      payload: { tagId: TEST_TAG_ID, tagName: 'e2ehandler' },
+    });
+    await app.inject({
+      method: 'POST',
+      url: `/v1/nodes/${TEST_NODE_ID}/tags`,
+      payload: { tagName: 'e2ehandler' },
+    });
+
+    await handler.pollOnce();
+
+    // Daily note should show the tag
+    const dnResponse = await app.inject({ method: 'GET', url: `/v1/daily-notes/${DATE}` });
+    const dnBody = dnResponse.json<{ nodes: Array<{ nodeId: string; tags: string[] }> }>();
+    const node = dnBody.nodes.find((n) => n.nodeId === TEST_NODE_ID);
+    expect(node?.tags).toContain('e2ehandler');
+
+    // Tag lens should have the node
+    const lensResponse = await app.inject({
+      method: 'GET',
+      url: `/v1/tags/${TEST_TAG_ID}/lens`,
+    });
+    const lensBody = lensResponse.json<{ nodes: Array<{ nodeId: string }> }>();
+    expect(lensBody.nodes.some((n) => n.nodeId === TEST_NODE_ID)).toBe(true);
+  });
+
+  it('projects NodeUntagged — removes from tag lens and clears tag from daily note', async () => {
+    await app.inject({
+      method: 'DELETE',
+      url: `/v1/nodes/${TEST_NODE_ID}/tags/${TEST_TAG_ID}`,
+    });
+
+    await handler.pollOnce();
+
+    const lensResponse = await app.inject({
+      method: 'GET',
+      url: `/v1/tags/${TEST_TAG_ID}/lens`,
+    });
+    const lensBody = lensResponse.json<{ nodes: Array<{ nodeId: string }> }>();
+    expect(lensBody.nodes.some((n) => n.nodeId === TEST_NODE_ID)).toBe(false);
+
+    const dnResponse = await app.inject({ method: 'GET', url: `/v1/daily-notes/${DATE}` });
+    const dnBody = dnResponse.json<{ nodes: Array<{ nodeId: string; tags: string[] }> }>();
+    const node = dnBody.nodes.find((n) => n.nodeId === TEST_NODE_ID);
+    expect(node?.tags).not.toContain('e2ehandler');
+  });
+
+  it('projects NodeDeleted — removes from daily note', async () => {
+    await app.inject({ method: 'DELETE', url: `/v1/nodes/${TEST_NODE_ID}` });
+
+    await handler.pollOnce();
+
+    const response = await app.inject({ method: 'GET', url: `/v1/daily-notes/${DATE}` });
+    const body = response.json<{ nodes: Array<{ nodeId: string }> }>();
+    expect(body.nodes.some((n) => n.nodeId === TEST_NODE_ID)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements issue #8: `ProjectionHandlerService` polls `IEventStore.getEventsSince()` on a configurable interval (env `PROJECTION_POLL_INTERVAL_MS`, default 500ms), replaying all events from id=0 on startup
- Handles all 7 event types: NodeCreated, NodeEdited, NodeMoved, NodeDeleted, TagCreated, NodeTagged, NodeUntagged
- Maintains an in-memory `Map<nodeId, NodeState>` so edit/move/delete/tag events can resolve `dailyNoteDate`, `content`, `tags` etc. without additional DB queries
- `pollOnce()` is public — e2e tests call it directly instead of sleeping
- Bugfix: `postgres-projection-store` was passing `JSON.stringify(tags)` to a `TEXT[]` column — changed to pass the native JS array (pg driver handles the conversion)

## Test plan

- [x] `pnpm --filter @notebase/api test` — 29 unit tests pass
- [x] Ensure `docker compose up` is running
- [x] `pnpm --filter @notebase/api test:e2e` — 28 tests pass across all 5 suites
- [x] Manual full cycle: create a node → tag it → check `GET /v1/daily-notes/:date` shows the tag → check `GET /v1/tags/:tagId/lens` shows the node → untag it → verify tag lens is empty → delete node → verify daily note is empty

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)